### PR TITLE
optimize statistics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,10 +5,10 @@ Goose is a Rust load testing tool, based on Locust.
 ### In progress
 
 - [ ] automated testing of Goose logic
-- [ ] optimize statistics
-  - [ ] round and group response times
-  - [ ] maintain running min/max/average
-  - [ ] offload to parent process as much as possible
+- [x] optimize statistics
+  - [x] round and group response times
+  - [x] maintain running min/max/average
+  - [x] offload to parent process as much as possible
 - [ ] --stop-timeout to gracefully exit client threads
   - [ ] add polling to sleeping clients to exit quicker
 - [ ] detect/report when available CPU power is bottleneck

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,13 @@ Goose is a Rust load testing tool, based on Locust.
 ### In progress
 
 - [ ] automated testing of Goose logic
+- [ ] optimize statistics
+  - [ ] round and group response times
+  - [ ] maintain running min/max/average
+  - [ ] offload to parent process as much as possible
+- [ ] --stop-timeout to gracefully exit client threads
+  - [ ] add polling to sleeping clients to exit quicker
+- [ ] detect/report when available CPU power is bottleneck
 
 ### Future (post-MVP)
 
@@ -14,7 +21,6 @@ Goose is a Rust load testing tool, based on Locust.
 - [ ] more complicated wait_time implementations  
   - [ ] constant pacing (https://github.com/locustio/locust/blob/795b5a14dd5b0991fec5a7f96f0d6491ce19e3d0/locust/wait_time.py#L30)  
   - [ ] custom wait_time implementations  
-- [ ] --stop-timeout to gracefully exit client threads  
 - [ ] documentation  
 - [ ] website  
 - [ ] gaggle support (distributed Geese)  

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -344,6 +344,8 @@ pub struct GooseRequest {
     pub max_response_time: usize,
     /// Total combined response times seen so far.
     pub total_response_time: usize,
+    /// Total number of response times seen so far.
+    pub response_time_counter: usize,
     /// Per-status-code counters, tracking how often each response code was returned for this request.
     pub status_code_counts: HashMap<u16, usize>,
     /// Total number of times this path-method request resulted in a successful (2xx) status code.
@@ -362,6 +364,7 @@ impl GooseRequest {
             min_response_time: 0,
             max_response_time: 0,
             total_response_time: 0,
+            response_time_counter: 0,
             status_code_counts: HashMap::new(),
             success_count: 0,
             fail_count: 0,
@@ -396,12 +399,15 @@ impl GooseRequest {
         }
 
         // Update max_response_time if this one is slowest yet.
-        if rounded_response_time > self.min_response_time {
+        if rounded_response_time > self.max_response_time {
             self.max_response_time = rounded_response_time;
         }
 
         // Update total_respone time, adding in this one.
         self.total_response_time += rounded_response_time;
+
+        // Increment counter tracking total number of response times seen.
+        self.response_time_counter += 1;
 
         let counter = match self.response_times.get(&rounded_response_time) {
             // We've seen this response_time before, increment counter.

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -173,7 +173,7 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, BTreeMap};
 use std::time::Instant;
 
 use http::StatusCode;
@@ -337,7 +337,7 @@ pub struct GooseRequest {
     /// The method for which statistics are being collected.
     pub method: Method,
     /// Per-response-time counters, tracking how often pages are returned with this response time.
-    pub response_times: HashMap<usize, usize>,
+    pub response_times: BTreeMap<usize, usize>,
     /// The shortest response time seen so far.
     pub min_response_time: usize,
     /// The longest response time seen so far.
@@ -360,7 +360,7 @@ impl GooseRequest {
         GooseRequest {
             path: path.to_string(),
             method: method,
-            response_times: HashMap::new(),
+            response_times: BTreeMap::new(),
             min_response_time: 0,
             max_response_time: 0,
             total_response_time: 0,
@@ -399,7 +399,7 @@ impl GooseRequest {
         }
 
         // Update max_response_time if this one is slowest yet.
-        if rounded_response_time > self.max_response_time {
+        if rounded_response_time > self.min_response_time {
             self.max_response_time = rounded_response_time;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1070,7 +1070,7 @@ pub fn merge_response_times(
         let counter = match global_response_times.get(&response_time) {
             // We've seen this response_time before, increment counter.
             Some(c) => {
-                *c + 1
+                *c + count
             }
             // First time we've seen this response time, initialize counter.
             None => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1062,9 +1062,9 @@ fn timer_expired(started: time::Instant, run_time: usize) -> bool {
 
 // Merge local response times into global response times.
 pub fn merge_response_times(
-    mut global_response_times: HashMap<usize, usize>,
-    local_response_times: HashMap<usize, usize>,
-) -> HashMap<usize, usize> {
+    mut global_response_times: BTreeMap<usize, usize>,
+    local_response_times: BTreeMap<usize, usize>,
+) -> BTreeMap<usize, usize> {
     // Iterate over client response times, and merge into global response times.
     for (response_time, count) in &local_response_times {
         let counter = match global_response_times.get(&response_time) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1114,6 +1114,8 @@ fn merge_from_client(
     );
     // Increment total response time counter.
     merged_request.total_response_time += &client_request.total_response_time;
+    // Increment count of how many resposne counters we've seen.
+    merged_request.response_time_counter += &client_request.response_time_counter;
     // If client had new fastest response time, update global fastest response time.
     merged_request.min_response_time = update_min_response_time(merged_request.min_response_time, client_request.min_response_time);
     // If client had new slowest response time, update global slowest resposne time.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1060,6 +1060,44 @@ fn timer_expired(started: time::Instant, run_time: usize) -> bool {
     }
 }
 
+// Merge local response times into global response times.
+pub fn merge_response_times(
+    mut global_response_times: HashMap<usize, usize>,
+    local_response_times: HashMap<usize, usize>,
+) -> HashMap<usize, usize> {
+    // Iterate over client response times, and merge into global response times.
+    for (response_time, count) in &local_response_times {
+        let counter = match global_response_times.get(&response_time) {
+            // We've seen this response_time before, increment counter.
+            Some(c) => {
+                *c + 1
+            }
+            // First time we've seen this response time, initialize counter.
+            None => {
+                *count
+            }
+        };
+        global_response_times.insert(*response_time, counter);
+    }
+    global_response_times
+}
+
+// Update global minimum response time based on local resposne time.
+fn update_min_response_time(mut global_min: usize, min: usize) -> usize {
+    if global_min == 0 || (min > 0 && min < global_min) {
+        global_min = min;
+    }
+    global_min
+}
+
+// Update global maximum response time based on local resposne time.
+fn update_max_response_time(mut global_max: usize, max: usize) -> usize {
+    if global_max < max {
+        global_max = max;
+    }
+    global_max
+}
+
 /// Merge per-client-statistics from client thread into global parent statistics
 fn merge_from_client(
     parent_request: &GooseRequest,
@@ -1070,31 +1108,16 @@ fn merge_from_client(
     let mut merged_request = parent_request.clone();
 
     // Iterate over client response times, and merge into global response times.
-    for (response_time, count) in &client_request.response_times {
-        let counter = match merged_request.response_times.get(&response_time) {
-            // We've seen this response_time before, increment counter.
-            Some(c) => {
-                *c + 1
-            }
-            // First time we've seen this response time, initialize counter.
-            None => {
-                *count
-            }
-        };
-        merged_request.response_times.insert(*response_time, counter);
-    }
+    merged_request.response_times = merge_response_times(
+        merged_request.response_times,
+        client_request.response_times.clone(),
+    );
     // Increment total response time counter.
     merged_request.total_response_time += &client_request.total_response_time;
     // If client had new fastest response time, update global fastest response time.
-    if merged_request.min_response_time == 0 ||
-        (client_request.min_response_time > 0 && client_request.min_response_time < merged_request.min_response_time)
-    {
-        merged_request.min_response_time = client_request.min_response_time;
-    }
+    merged_request.min_response_time = update_min_response_time(merged_request.min_response_time, client_request.min_response_time);
     // If client had new slowest response time, update global slowest resposne time.
-    if merged_request.max_response_time < client_request.max_response_time {
-        merged_request.max_response_time = client_request.max_response_time;
-    }
+    merged_request.max_response_time = update_max_response_time(merged_request.max_response_time, client_request.max_response_time);
     // Increment total success counter.
     merged_request.success_count += &client_request.success_count;
     // Increment total fail counter.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -90,7 +90,7 @@ fn print_response_times(requests: &HashMap<String, GooseRequest>, display_percen
     let mut aggregate_min_response_time: usize = 0;
     let mut aggregate_max_response_time: usize = 0;
     println!("-------------------------------------------------------------------------------");
-    println!(" {:<23} | {:<10} | {:<10} | {:<10} | {:<10}", "Name", "Avg (ms)", "Min", "Max", "Mean");
+    println!(" {:<23} | {:<10} | {:<10} | {:<10} | {:<10}", "Name", "Avg (ms)", "Min", "Max", "Median");
     println!(" ----------------------------------------------------------------------------- ");
     for (request_key, request) in requests.clone() {
         // Iterate over client response times, and merge into global response times.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,5 +1,5 @@
 use num_format::{Locale, ToFormattedString};
-use std::collections::HashMap;
+use std::collections::{HashMap, BTreeMap};
 use std::f32;
 
 use crate::{GooseState, util, merge_response_times, update_min_response_time, update_max_response_time};
@@ -84,7 +84,7 @@ fn print_requests_and_fails(requests: &HashMap<String, GooseRequest>, elapsed: u
 }
 
 fn print_response_times(requests: &HashMap<String, GooseRequest>, display_percentiles: bool) {
-    let mut aggregate_response_times: HashMap<usize, usize> = HashMap::new();
+    let mut aggregate_response_times: BTreeMap<usize, usize> = BTreeMap::new();
     let mut aggregate_total_response_time: usize = 0;
     let mut aggregate_response_time_counter: usize = 0;
     let mut aggregate_min_response_time: usize = 0;
@@ -92,7 +92,7 @@ fn print_response_times(requests: &HashMap<String, GooseRequest>, display_percen
     println!("-------------------------------------------------------------------------------");
     println!(" {:<23} | {:<10} | {:<10} | {:<10} | {:<10}", "Name", "Avg (ms)", "Min", "Max", "Mean");
     println!(" ----------------------------------------------------------------------------- ");
-    for (request_key, mut request) in requests.clone() {
+    for (request_key, request) in requests.clone() {
         // Iterate over client response times, and merge into global response times.
         aggregate_response_times = merge_response_times(
             aggregate_response_times,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -116,9 +116,7 @@ fn print_response_times(requests: &HashMap<String, GooseRequest>, display_percen
             request.total_response_time / request.response_time_counter,
             request.min_response_time,
             request.max_response_time,
-            // @TODO: fix median calculation
-            //util::median(&request.response_times),
-            0.0,
+            util::median(&request.response_times, request.response_time_counter, request.min_response_time, request.max_response_time),
         );
     }
     println!(" ------------------------+------------+------------+------------+------------- ");
@@ -127,8 +125,7 @@ fn print_response_times(requests: &HashMap<String, GooseRequest>, display_percen
         aggregate_total_response_time / aggregate_response_time_counter,
         aggregate_min_response_time,
         aggregate_max_response_time,
-        0.0,
-        //util::median(&aggregate_response_times),
+        util::median(&aggregate_response_times, aggregate_response_time_counter, aggregate_min_response_time, aggregate_max_response_time),
     );
 
     /*

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 use std::cmp::{min, max};
+use std::collections::BTreeMap;
 use std::str::FromStr;
 use regex::Regex;
 
@@ -50,21 +51,33 @@ pub fn gcd(u: usize, v: usize) -> usize {
     gcd
 }
 
-/// Calculate mean for a vector of f32s.
-pub fn mean(list: &[usize]) -> usize {
-    let sum: usize = Iterator::sum(list.iter());
-    usize::from(sum) / (list.len() as usize)
-}
-
-/// Calculate median for a vector of f32s.
-pub fn median(list: &[usize]) -> usize {
-    let len = list.len();
-    let mid = len / 2;
-    if len % 2 == 0 {
-        mean(&list[(mid - 1)..(mid + 1)])
-    } else {
-        list[mid]
+/// Calculate median for a BTreeMap of usizes.
+pub fn median(
+    btree: &BTreeMap<usize, usize>,
+    total_elements: usize,
+    min: usize,
+    max: usize,
+) -> usize {
+    let mut total_count: usize = 0;
+    let half_elements = total_elements / 2;
+    for (value, counter) in btree {
+        total_count += counter;
+        if total_count >= half_elements {
+            // We're working with rounded values, it's possible the mean is greater than the
+            // max response time, or smaller than the min response time -- in these cases
+            // return the actual values;
+            if *value > max {
+                return max;
+            }
+            else if *value < min {
+                return min;
+            }
+            else {
+                return *value;
+            }
+        }
     }
+    return 0
 }
 
 /// Truncate strings when they're too long to display.

--- a/src/util.rs
+++ b/src/util.rs
@@ -77,7 +77,7 @@ pub fn median(
             }
         }
     }
-    return 0
+    return min;
 }
 
 /// Truncate strings when they're too long to display.

--- a/src/util.rs
+++ b/src/util.rs
@@ -77,7 +77,7 @@ pub fn median(
             }
         }
     }
-    return min;
+    return 0;
 }
 
 /// Truncate strings when they're too long to display.


### PR DESCRIPTION
 - remove response_times from unordered HashMap to an ordered BTreeMap
 - round response_times to compress the data
 - maintain running min/max/total counters to minimize CPU overhead
 - rework median() to use grouped BTreeMap response time counters
 - rework calculation of percentiles to use grouped BTreeMap response time counters