### PR TITLE
poll regularly to exit to fix #3 

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,12 +5,8 @@ Goose is a Rust load testing tool, based on Locust.
 ### In progress
 
 - [ ] automated testing of Goose logic
-- [x] optimize statistics
-  - [x] round and group response times
-  - [x] maintain running min/max/average
-  - [x] offload to parent process as much as possible
 - [ ] --stop-timeout to gracefully exit client threads
-  - [ ] add polling to sleeping clients to exit quicker
+  - [x] add polling to sleeping clients to exit quicker
 - [ ] detect/report when available CPU power is bottleneck
 
 ### Future (post-MVP)
@@ -69,3 +65,7 @@ Goose is a Rust load testing tool, based on Locust.
 - [x] turn Goose into a library, create a loadtest by creating an app with Cargo  
   - [x] compare the pros/cons of this w/ going the dynamic library approach  
   - [x] upload to crates.io
+- [x] optimize statistics
+  - [x] round and group response times
+  - [x] maintain running min/max/average
+  - [x] offload to parent process as much as possible


### PR DESCRIPTION
Fixes #3 

 - wake clients regularly to poll for messages from the parent
 - exit quickly if parent sends GooseClientCommand::EXIT
 - send updated statistics quickly if parent sens GooseClientCommand::SYNC