### PR TITLE
PoC: attribute macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["loadtesting", "performance", "web", "framework", "tool"]
 license = "Apache-2.0"
 
 [dependencies]
-#goose_codegen = { path = "goose_codegen" }
+goose_codegen = { path = "goose_codegen" }
 ctrlc = "3.1"
 http = "0.2"
 lazy_static = "1.4"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -19,6 +19,7 @@
 
 use goose::boilerplate;
 boilerplate!();
+use goose_codegen::goose_client_callback;
 
 fn main() {
     GooseAttack::initialize()
@@ -27,10 +28,10 @@ fn main() {
             // After each task runs, sleep randomly from 5 to 15 seconds.
             .set_wait_time(5, 15)
             // This task only runs one time when the client first starts.
-            .register_task(GooseTask::new(task!(website_login)).set_on_start())
+            .register_task(GooseTask::new(website_login).set_on_start())
             // These next two tasks run repeatedly as long as the load test is running.
-            .register_task(GooseTask::new(task!(website_index)))
-            .register_task(GooseTask::new(task!(website_about)))
+            .register_task(GooseTask::new(website_index))
+            .register_task(GooseTask::new(website_about))
         )
         .execute();
 }
@@ -38,6 +39,7 @@ fn main() {
 /// Demonstrates how to log in when a client starts. We flag this task as an
 /// on_start task when registering it above. This means it only runs one time
 /// per client, when the client thread first starts.
+#[goose_client_callback]
 async fn website_login<'r>(client: &'r mut GooseClient) {
     let request_builder = client.goose_post("/login");
     // https://docs.rs/reqwest/*/reqwest/blocking/struct.RequestBuilder.html#method.form
@@ -46,11 +48,13 @@ async fn website_login<'r>(client: &'r mut GooseClient) {
 }
 
 /// A very simple task that simply loads the front page.
+#[goose_client_callback]
 async fn website_index<'r>(client: &'r mut GooseClient) {
     let _response = client.get("/").await;
 }
 
 /// A very simple task that simply loads the about page.
+#[goose_client_callback]
 async fn website_about<'r>(client: &'r mut GooseClient) {
     let _response = client.get("/about/").await;
 }

--- a/goose_codegen/Cargo.toml
+++ b/goose_codegen/Cargo.toml
@@ -10,5 +10,5 @@ crate_type = ["proc-macro"]
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = "1"
-
+# "extra-traits" is for Debug. Disable this when releasing to crates.io
+syn = { version = "1", features = ["extra-traits"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,8 +273,7 @@
 #[macro_use]
 extern crate log;
 
-//#[macro_use]
-//extern crate goose_codegen;
+extern crate goose_codegen;
 
 extern crate structopt;
 


### PR DESCRIPTION
I suspect that a function-like macro will be fine ergonomics-wise, but I thought I'd have a go at writing an attribute macro anyway.

It is pretty gnarly, so it probably wants a bunch of compiletests to exercise the various failure modes (probably using this crate: https://github.com/laumann/compiletest-rs , since I've used it to write tests in the main rustc repo and it's pretty excellent).